### PR TITLE
修复 [Bug] imagePathBase: "note" 整理图片时生成绝对路径而非相对路径

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -20,13 +20,14 @@ export default class ImageManagerPlugin extends Plugin {
     refConverter: RefConverter;
     imageOptimizer: ImageOptimizer;
     batchRename: BatchRename;
+    private isReorganizing = false;
     async onload() {
         await this.loadSettings();
         setLocale(this.settings.locale);
 
         this.refConverter = new RefConverter(this.app);
         this.imageOptimizer = new ImageOptimizer(this.app);
-        this.batchRename = new BatchRename(this.app);
+        this.batchRename = new BatchRename(this.app, this.settings);
 
         // Ribbon icon
         if (this.settings.enableImageBrowser) {
@@ -166,6 +167,7 @@ export default class ImageManagerPlugin extends Plugin {
         this.registerEvent(
             this.app.vault.on('rename', (file, oldPath) => {
                 if (!(file instanceof TFile) || !this.isImageFile(file)) return;
+                if (this.isReorganizing) return;
                 window.setTimeout(() => {
                     void this.batchRename.fixBrokenImageRefs(oldPath, file.path);
                 }, 100);
@@ -590,6 +592,7 @@ export default class ImageManagerPlugin extends Plugin {
 
     private async reorganizeNote(file: TFile) {
         const reorganizer = new ImageReorganizer(this.app, this.settings, this.resolveImagePath.bind(this));
+        this.isReorganizing = true;
         try {
             const result = await reorganizer.reorganizeNote(file, this.settings.reorganizeConvertFormat ? 'markdown' : undefined);
             new Notice(
@@ -601,11 +604,14 @@ export default class ImageManagerPlugin extends Plugin {
             );
         } catch (e) {
             new Notice(t('notice.reorganizeFailed', { error: e instanceof Error ? e.message : 'Unknown error' }));
+        } finally {
+            this.isReorganizing = false;
         }
     }
 
     private async reorganizeFolder(folderPath: string) {
         const reorganizer = new ImageReorganizer(this.app, this.settings, this.resolveImagePath.bind(this));
+        this.isReorganizing = true;
         try {
             const result = await reorganizer.reorganizeFolder(folderPath, this.settings.reorganizeConvertFormat ? 'markdown' : undefined);
             new Notice(
@@ -617,6 +623,8 @@ export default class ImageManagerPlugin extends Plugin {
             );
         } catch (e) {
             new Notice(t('notice.reorganizeFailed', { error: e instanceof Error ? e.message : 'Unknown error' }));
+        } finally {
+            this.isReorganizing = false;
         }
     }
 

--- a/src/utils/batch-rename.ts
+++ b/src/utils/batch-rename.ts
@@ -1,5 +1,6 @@
 import { App, TFile } from 'obsidian';
 import { RefConverter } from './ref-converter';
+import type { ImageManagerSettings } from '../types';
 
 export interface RenameResult {
     file: TFile;
@@ -11,10 +12,12 @@ export interface RenameResult {
 export class BatchRename {
     private app: App;
     private refConverter: RefConverter;
+    private settings: ImageManagerSettings;
 
-    constructor(app: App) {
+    constructor(app: App, settings: ImageManagerSettings) {
         this.app = app;
         this.refConverter = new RefConverter(app);
+        this.settings = settings;
     }
 
     /**
@@ -110,9 +113,34 @@ export class BatchRename {
 
                 if (ref.path !== newName && ref.path.split('/').pop() !== newName) continue;
 
+                // Skip if reference already points to a valid file
+                let decodedRefPath: string;
+                try {
+                    decodedRefPath = decodeURIComponent(ref.path);
+                } catch {
+                    decodedRefPath = ref.path;
+                }
+                // Try exact path, then resolve relative to note directory
+                const noteDir = mdFile.parent?.path ?? '';
+                const resolvedPath = noteDir ? `${noteDir}/${decodedRefPath}` : decodedRefPath;
+                if (this.app.vault.getAbstractFileByPath(decodedRefPath) ||
+                    this.app.vault.getAbstractFileByPath(resolvedPath)) continue;
+
                 // Restore directory path
-                const dir = oldPath.substring(0, oldPath.lastIndexOf('/'));
-                const correctPath = dir ? `${dir}/${newName}` : newName;
+                // For moves (directory changed), use new location; for renames, use old directory
+                const oldDir = oldPath.substring(0, oldPath.lastIndexOf('/'));
+                const newDir = newPath.substring(0, newPath.lastIndexOf('/'));
+                const dir = oldDir !== newDir ? newDir : oldDir;
+                const absolutePath = dir ? `${dir}/${newName}` : newName;
+
+                // Compute correct path: relative to note if imagePathBase is 'note'
+                let correctPath = absolutePath;
+                if (this.settings.imagePathBase === 'note' && ref.format === 'markdown') {
+                    const noteDir = mdFile.parent?.path ?? '';
+                    if (noteDir) {
+                        correctPath = this.refConverter.computeRelativePath(noteDir, absolutePath);
+                    }
+                }
                 if (ref.path === correctPath) continue;
 
                 // Update alt text if it was the old filename

--- a/src/utils/image-reorganizer.ts
+++ b/src/utils/image-reorganizer.ts
@@ -33,7 +33,6 @@ export class ImageReorganizer {
         let newContent = content;
         let moved = 0;
         let skipped = 0;
-        let converted = 0;
 
         // Process in reverse order to preserve indices
         for (let i = refs.length - 1; i >= 0; i--) {
@@ -66,13 +65,6 @@ export class ImageReorganizer {
             // Determine the output format: use convertFormat if provided, otherwise keep original
             const outputFormat: ReferenceFormat = convertFormat ?? ref.format;
             const needsMove = imageFile.path !== targetPath;
-            const needsFormatChange = convertFormat !== undefined && ref.format !== convertFormat;
-
-            // Skip if nothing needs to change
-            if (!needsMove && !needsFormatChange) {
-                skipped++;
-                continue;
-            }
 
             // Move file if needed
             let finalPath = imageFile.path;
@@ -89,7 +81,15 @@ export class ImageReorganizer {
                 const fileName = finalPath.split('/').pop() ?? finalPath;
                 newRef = ref.altText ? `![[${fileName}|${ref.altText}]]` : `![[${fileName}]]`;
             } else {
-                const encodedPath = encodePathSegments(finalPath);
+                // For markdown format, compute relative path if imagePathBase is 'note'
+                let refPath = finalPath;
+                if (this.settings.imagePathBase === 'note') {
+                    const noteDir = noteFile.parent?.path ?? '';
+                    if (noteDir) {
+                        refPath = this.refConverter.computeRelativePath(noteDir, finalPath);
+                    }
+                }
+                const encodedPath = encodePathSegments(refPath);
                 newRef = `![${ref.altText}](${encodedPath})`;
             }
 
@@ -98,11 +98,10 @@ export class ImageReorganizer {
                     newContent.substring(0, ref.col) +
                     newRef +
                     newContent.substring(ref.col + ref.fullMatch.length);
-                if (needsFormatChange) converted++;
             }
         }
 
-        if (moved > 0 || converted > 0) {
+        if (newContent !== content) {
             await this.app.vault.process(noteFile, () => newContent);
             if (moved > 0) {
                 await this.updateOtherNotes(noteFile);
@@ -159,12 +158,16 @@ export class ImageReorganizer {
         return this.settings.supportedExtensions.includes(file.extension.toLowerCase());
     }
 
-    private buildRefPath(vaultPath: string, format: 'wiki' | 'markdown'): string {
+    private buildRefPath(vaultPath: string, format: 'wiki' | 'markdown', noteDir?: string): string {
         if (format === 'wiki') {
             return vaultPath.split('/').pop() ?? vaultPath;
         }
-        // Markdown: URL-encode each path segment
-        return encodePathSegments(vaultPath);
+        // Markdown: compute relative path if noteDir is provided and imagePathBase is 'note'
+        let refPath = vaultPath;
+        if (noteDir && this.settings.imagePathBase === 'note') {
+            refPath = this.refConverter.computeRelativePath(noteDir, vaultPath);
+        }
+        return encodePathSegments(refPath);
     }
 
     private async ensureDirectory(dirPath: string): Promise<void> {
@@ -230,7 +233,8 @@ export class ImageReorganizer {
                 if (!match) continue;
 
                 // Build new reference
-                const newRefPath = this.buildRefPath(match.path, ref.format);
+                const noteDir = mdFile.parent?.path ?? '';
+                const newRefPath = this.buildRefPath(match.path, ref.format, noteDir);
                 let newRef: string;
                 if (ref.format === 'wiki') {
                     const fileName = match.path.split('/').pop() ?? match.path;

--- a/src/utils/ref-converter.ts
+++ b/src/utils/ref-converter.ts
@@ -87,7 +87,7 @@ export class RefConverter {
     }
 
     /** 计算从 fromDir 到 toPath 的相对路径 */
-    private computeRelativePath(fromDir: string, toPath: string): string {
+    computeRelativePath(fromDir: string, toPath: string): string {
         const fromParts = fromDir.split('/').filter(Boolean);
         const toParts = toPath.split('/').filter(Boolean);
 


### PR DESCRIPTION
1. 修复图片移动、重命名更新原有引用与 Obsidian'始终更新内部链接'的冲突
2. 修复 [Bug] imagePathBase: "note" 整理图片时生成绝对路径而非相对路径 fixes #1 