### PR TITLE
fix: 修复 MinIO/S3 路径构造与签名编码

### DIFF
--- a/.agents/skills/obsidian-image-manager/references/uploaders.md
+++ b/.agents/skills/obsidian-image-manager/references/uploaders.md
@@ -52,7 +52,7 @@ abstract class UploaderBase {
 
 - **协议**：PUT 请求
 - **签名**：AWS Signature V4（`AWS4-HMAC-SHA256`）
-- **路径编码**：`s3-path.ts` 对 key 逐段 URL 编码，请求 URL 与 canonical URI 必须使用相同结果
+- **路径编码**：`s3-path.ts` 按 AWS SigV4 的未保留字符集对 key 逐段编码，请求 URL 与 canonical URI 必须使用相同结果
 - **URL 风格**：
   - path-style：`https://{endpoint}/{bucket}/{key}`
   - virtual-hosted：`https://{bucket}.{endpoint}/{key}`

--- a/.agents/skills/obsidian-image-manager/references/uploaders.md
+++ b/.agents/skills/obsidian-image-manager/references/uploaders.md
@@ -52,10 +52,12 @@ abstract class UploaderBase {
 
 - **协议**：PUT 请求
 - **签名**：AWS Signature V4（`AWS4-HMAC-SHA256`）
+- **路径编码**：`s3-path.ts` 对 key 逐段 URL 编码，请求 URL 与 canonical URI 必须使用相同结果
 - **URL 风格**：
   - path-style：`https://{endpoint}/{bucket}/{key}`
   - virtual-hosted：`https://{bucket}.{endpoint}/{key}`
 - **配置**：`forcePathStyle` 可选
+- **公开 URL**：`urlPrefix` 完全由用户配置，不根据 `forcePathStyle` 自动追加 bucket
 
 ### 自定义 (`custom-uploader.ts`)
 

--- a/src/uploaders/s3-compatible.ts
+++ b/src/uploaders/s3-compatible.ts
@@ -76,12 +76,19 @@ export class S3Uploader extends UploaderBase {
     }
 
     private buildUrl(s3Config: S3Config, key: string): string {
-        const endpoint = s3Config.endpoint.replace(/\/$/, '');
+        let endpoint = s3Config.endpoint.replace(/\/$/, '');
+        // 确保端点包含协议前缀，缺失时默认使用 https
+        if (!/^https?:\/\//.test(endpoint)) {
+            endpoint = 'https://' + endpoint;
+        }
         if (s3Config.forcePathStyle) {
-            return `${endpoint}/${s3Config.bucket}/${key}`;
+            const encodedKey = encodeURIComponent(key).replace(/%2F/g, '/');
+            return `${endpoint}/${s3Config.bucket}/${encodedKey}`;
         }
         // Virtual-hosted style
-        return `https://${s3Config.bucket}.${endpoint.replace(/^https?:\/\//, '')}/${key}`;
+        const hostPart = endpoint.replace(/^https?:\/\//, '');
+        const encodedKey = encodeURIComponent(key).replace(/%2F/g, '/');
+        return `${new URL(endpoint).protocol}//${s3Config.bucket}.${hostPart}/${encodedKey}`;
     }
 
     private async signRequest(
@@ -100,9 +107,11 @@ export class S3Uploader extends UploaderBase {
         const canonicalHeaders = `content-type:${contentType}\nhost:${requestHost}\nx-amz-content-sha256:${payloadHash}\nx-amz-date:${amzDate}\n`;
         const signedHeaders = 'content-type;host;x-amz-content-sha256;x-amz-date';
 
+        // Path-style 模式下 bucket 在路径中，canonical URI 必须包含 bucket
+        const canonicalUri = s3Config.forcePathStyle ? `/${s3Config.bucket}/${key}` : `/${key}`;
         const canonicalRequest = [
             method,
-            `/${key}`,
+            canonicalUri,
             '', // query string
             canonicalHeaders,
             signedHeaders,

--- a/src/uploaders/s3-compatible.ts
+++ b/src/uploaders/s3-compatible.ts
@@ -1,5 +1,6 @@
 import { requestUrl } from 'obsidian';
 import { UploaderBase } from './uploader-base';
+import { buildS3CanonicalUri, buildS3Url, encodeS3Key } from './s3-path';
 import type { UploadResult, ImageHostingConfig, S3Config } from '../types';
 
 export class S3Uploader extends UploaderBase {
@@ -15,7 +16,7 @@ export class S3Uploader extends UploaderBase {
         const contentType = this.guessMimeType(filename);
 
         try {
-            const url = this.buildUrl(s3Config, targetPath);
+            const url = buildS3Url(s3Config, targetPath);
             const requestHost = new URL(url).host;
             const headers = await this.signRequest(s3Config, 'PUT', targetPath, requestHost, data, contentType);
 
@@ -38,9 +39,8 @@ export class S3Uploader extends UploaderBase {
                 };
             }
 
-            // Path-style 模式下 urlPrefix 拼接需包含 bucket
             const publicUrl = this.config.urlPrefix
-                ? `${this.config.urlPrefix}/${s3Config.forcePathStyle ? s3Config.bucket + "/" : ""}${targetPath}`
+                ? `${this.config.urlPrefix.replace(/\/+$/, '')}/${encodeS3Key(targetPath)}`
                 : url;
 
             return {
@@ -61,7 +61,7 @@ export class S3Uploader extends UploaderBase {
         const s3Config = this.config.config as S3Config;
 
         try {
-            const url = this.buildUrl(s3Config, '');
+            const url = buildS3Url(s3Config, '');
             const requestHost = new URL(url).host;
             const headers = await this.signRequest(s3Config, 'GET', '', requestHost, new ArrayBuffer(0));
             const resp = await requestUrl({
@@ -74,22 +74,6 @@ export class S3Uploader extends UploaderBase {
         } catch {
             return false;
         }
-    }
-
-    private buildUrl(s3Config: S3Config, key: string): string {
-        let endpoint = s3Config.endpoint.replace(/\/$/, '');
-        // 确保端点包含协议前缀，缺失时默认使用 https
-        if (!/^https?:\/\//.test(endpoint)) {
-            endpoint = 'https://' + endpoint;
-        }
-        if (s3Config.forcePathStyle) {
-            const encodedKey = encodeURIComponent(key).replace(/%2F/g, '/');
-            return `${endpoint}/${s3Config.bucket}/${encodedKey}`;
-        }
-        // Virtual-hosted style
-        const hostPart = endpoint.replace(/^https?:\/\//, '');
-        const encodedKey = encodeURIComponent(key).replace(/%2F/g, '/');
-        return `${new URL(endpoint).protocol}//${s3Config.bucket}.${hostPart}/${encodedKey}`;
     }
 
     private async signRequest(
@@ -108,8 +92,7 @@ export class S3Uploader extends UploaderBase {
         const canonicalHeaders = `content-type:${contentType}\nhost:${requestHost}\nx-amz-content-sha256:${payloadHash}\nx-amz-date:${amzDate}\n`;
         const signedHeaders = 'content-type;host;x-amz-content-sha256;x-amz-date';
 
-        // Path-style 模式下 bucket 在路径中，canonical URI 必须包含 bucket
-        const canonicalUri = s3Config.forcePathStyle ? `/${s3Config.bucket}/${key}` : `/${key}`;
+        const canonicalUri = buildS3CanonicalUri(s3Config, key);
         const canonicalRequest = [
             method,
             canonicalUri,

--- a/src/uploaders/s3-compatible.ts
+++ b/src/uploaders/s3-compatible.ts
@@ -38,8 +38,9 @@ export class S3Uploader extends UploaderBase {
                 };
             }
 
+            // Path-style 模式下 urlPrefix 拼接需包含 bucket
             const publicUrl = this.config.urlPrefix
-                ? `${this.config.urlPrefix}/${targetPath}`
+                ? `${this.config.urlPrefix}/${s3Config.forcePathStyle ? s3Config.bucket + "/" : ""}${targetPath}`
                 : url;
 
             return {

--- a/src/uploaders/s3-path.ts
+++ b/src/uploaders/s3-path.ts
@@ -1,0 +1,33 @@
+import type { S3Config } from '../types';
+
+function normalizeEndpoint(endpoint: string): string {
+    const normalized = /^https?:\/\//i.test(endpoint) ? endpoint : `https://${endpoint}`;
+    return normalized.replace(/\/+$/, '');
+}
+
+/** Encode each S3 key segment while preserving path separators. */
+export function encodeS3Key(key: string): string {
+    return key.split('/').map((segment) => encodeURIComponent(segment)).join('/');
+}
+
+/** Build the request URL for path-style and virtual-hosted-style S3 endpoints. */
+export function buildS3Url(s3Config: S3Config, key: string): string {
+    const endpoint = normalizeEndpoint(s3Config.endpoint);
+    const encodedKey = encodeS3Key(key);
+
+    if (s3Config.forcePathStyle) {
+        return `${endpoint}/${s3Config.bucket}/${encodedKey}`;
+    }
+
+    const endpointUrl = new URL(endpoint);
+    const endpointPath = endpointUrl.pathname.replace(/\/+$/, '');
+    return `${endpointUrl.protocol}//${s3Config.bucket}.${endpointUrl.host}${endpointPath}/${encodedKey}`;
+}
+
+/** Build the encoded URI that must match the path used by AWS Signature V4. */
+export function buildS3CanonicalUri(s3Config: S3Config, key: string): string {
+    const encodedKey = encodeS3Key(key);
+    return s3Config.forcePathStyle
+        ? `/${s3Config.bucket}/${encodedKey}`
+        : `/${encodedKey}`;
+}

--- a/src/uploaders/s3-path.ts
+++ b/src/uploaders/s3-path.ts
@@ -7,7 +7,12 @@ function normalizeEndpoint(endpoint: string): string {
 
 /** Encode each S3 key segment while preserving path separators. */
 export function encodeS3Key(key: string): string {
-    return key.split('/').map((segment) => encodeURIComponent(segment)).join('/');
+    return key
+        .split('/')
+        .map((segment) => encodeURIComponent(segment).replace(/[!'()*]/g, (character) =>
+            `%${character.charCodeAt(0).toString(16).toUpperCase()}`
+        ))
+        .join('/');
 }
 
 /** Build the request URL for path-style and virtual-hosted-style S3 endpoints. */

--- a/tests/s3-compatible.test.ts
+++ b/tests/s3-compatible.test.ts
@@ -55,6 +55,17 @@ describe('S3 path construction', () => {
         );
         expect(buildS3CanonicalUri(config, 'folder/a b.png')).toBe('/folder/a%20b.png');
     });
+
+    it('encodes characters excluded by the AWS SigV4 unreserved set', () => {
+        const config = createS3Config();
+
+        expect(buildS3Url(config, "folder/!file'()*.png")).toBe(
+            'https://minio.example.com:9000/images/folder/%21file%27%28%29%2A.png'
+        );
+        expect(buildS3CanonicalUri(config, "folder/!file'()*.png")).toBe(
+            '/images/folder/%21file%27%28%29%2A.png'
+        );
+    });
 });
 
 describe('S3Uploader', () => {

--- a/tests/s3-compatible.test.ts
+++ b/tests/s3-compatible.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ImageHostingConfig, S3Config } from '../src/types';
+
+const { requestUrl } = vi.hoisted(() => ({ requestUrl: vi.fn() }));
+
+vi.mock('obsidian', () => ({ requestUrl }));
+
+import { S3Uploader } from '../src/uploaders/s3-compatible';
+import { buildS3CanonicalUri, buildS3Url } from '../src/uploaders/s3-path';
+
+function createS3Config(overrides: Partial<S3Config> = {}): S3Config {
+    return {
+        endpoint: 'minio.example.com:9000',
+        region: 'us-east-1',
+        accessKeyId: 'access-key',
+        secretAccessKey: 'secret-key',
+        bucket: 'images',
+        forcePathStyle: true,
+        ...overrides,
+    };
+}
+
+function createHostingConfig(s3Config: S3Config, urlPrefix = ''): ImageHostingConfig {
+    return {
+        id: 's3-test',
+        name: 'S3 test',
+        type: 's3',
+        enabled: true,
+        config: s3Config,
+        uploadPath: 'uploads/{filename}.{ext}',
+        urlPrefix,
+    };
+}
+
+describe('S3 path construction', () => {
+    it('adds HTTPS and builds a path-style URL with encoded key segments', () => {
+        const config = createS3Config();
+
+        expect(buildS3Url(config, 'folder/中文 图.png')).toBe(
+            'https://minio.example.com:9000/images/folder/%E4%B8%AD%E6%96%87%20%E5%9B%BE.png'
+        );
+        expect(buildS3CanonicalUri(config, 'folder/中文 图.png')).toBe(
+            '/images/folder/%E4%B8%AD%E6%96%87%20%E5%9B%BE.png'
+        );
+    });
+
+    it('preserves HTTP and builds a virtual-hosted-style URL', () => {
+        const config = createS3Config({
+            endpoint: 'http://s3.example.com:9000',
+            forcePathStyle: false,
+        });
+
+        expect(buildS3Url(config, 'folder/a b.png')).toBe(
+            'http://images.s3.example.com:9000/folder/a%20b.png'
+        );
+        expect(buildS3CanonicalUri(config, 'folder/a b.png')).toBe('/folder/a%20b.png');
+    });
+});
+
+describe('S3Uploader', () => {
+    beforeEach(() => {
+        requestUrl.mockReset();
+        requestUrl.mockResolvedValue({ status: 200, text: '' });
+    });
+
+    it('uses the encoded request path when uploading', async () => {
+        const uploader = new S3Uploader(createHostingConfig(createS3Config()));
+
+        const result = await uploader.upload(new ArrayBuffer(0), '中文 图.png');
+
+        expect(requestUrl).toHaveBeenCalledWith(expect.objectContaining({
+            url: 'https://minio.example.com:9000/images/uploads/%E4%B8%AD%E6%96%87%20%E5%9B%BE.png',
+        }));
+        expect(result).toMatchObject({
+            success: true,
+            url: 'https://minio.example.com:9000/images/uploads/%E4%B8%AD%E6%96%87%20%E5%9B%BE.png',
+        });
+    });
+
+    it('does not add the bucket to a configured public URL prefix', async () => {
+        const uploader = new S3Uploader(
+            createHostingConfig(createS3Config(), 'https://cdn.example.com/root/')
+        );
+
+        const result = await uploader.upload(new ArrayBuffer(0), '中文 图.png');
+
+        expect(result.url).toBe(
+            'https://cdn.example.com/root/uploads/%E4%B8%AD%E6%96%87%20%E5%9B%BE.png'
+        );
+    });
+});


### PR DESCRIPTION
## 变更说明

本 PR 接管并拆分自 #5，保留了 @jankenliu 的两个原始提交及 Author 信息：

- [`a755d67`](https://github.com/ytahml/obsidian-image-manager/commit/a755d675b2b07beab603e1536692cba6800d3b94)
- [`74ca065`](https://github.com/ytahml/obsidian-image-manager/commit/74ca0658292e08dea523d111a5b34dbe57479e63)

感谢 @jankenliu 对 MinIO/S3 兼容问题的定位和修复。

## 后续修正

- URL 前缀完全由用户配置，不再根据 `forcePathStyle` 自动追加 bucket。
- S3 key 按路径段编码，请求 URL 与 AWS SigV4 canonical URI 使用一致的编码结果。
- 保留 endpoint 的 HTTP/HTTPS 协议，缺失协议时默认使用 HTTPS。
- 新增 path-style、virtual-hosted-style、中文、空格和 URL 前缀测试。
- 同步更新项目上传器技能文档。

#5 中新增的 `{filePath}` 功能提交不包含在本 PR 内，后续应通过独立 issue/PR 整理和审查。

## 验证

- `npm test`：4 个测试文件、30 个用例通过
- `npm run build`：ESLint、TypeScript 和 esbuild 生产构建通过
- `git diff --check`：通过
