### PR TITLE
fix: Aliyun OSS 对象路径编码与 V1 签名保持一致

### DIFF
--- a/.agents/skills/obsidian-image-manager/SKILL.md
+++ b/.agents/skills/obsidian-image-manager/SKILL.md
@@ -24,6 +24,7 @@ main.ts (entry, ~995 lines)
 ├── uploaders/
 │   ├── uploader-factory.ts → 4 uploaders
 │   ├── upload-path.ts (shared template resolution)
+│   ├── oss-path.ts (Aliyun OSS URL path encoding)
 │   └── upload-queue.ts (3 concurrent, 3 retries)
 ├── utils/
 │   ├── ref-converter.ts ← constants.ts (regex)

--- a/.agents/skills/obsidian-image-manager/references/uploaders.md
+++ b/.agents/skills/obsidian-image-manager/references/uploaders.md
@@ -11,6 +11,7 @@ UploaderBase（抽象基类）
 
 createUploader(config)  ← 工厂函数
 upload-path.ts          ← 共享模板解析与优先级
+oss-path.ts             ← Aliyun OSS 对象 key URL 编码
 UploadQueue             ← 并发队列
 ```
 
@@ -45,6 +46,7 @@ abstract class UploaderBase {
 - **协议**：直接 PUT 请求
 - **签名**：HMAC-SHA1 签名 `Authorization: OSS` 头
 - **上传路径**：模板变量替换（含 SHA-256 hash）
+- **路径编码**：请求 URL 与公开 URL 按路径段编码；V1 `CanonicalizedResource` 保留原始逻辑对象 key
 - **端点**：`https://{bucket}.{region}.aliyuncs.com`
 
 ### 七牛云 (`qiniu.ts`)

--- a/src/uploaders/aliyun-oss.ts
+++ b/src/uploaders/aliyun-oss.ts
@@ -1,5 +1,6 @@
 import { requestUrl } from 'obsidian';
 import { UploaderBase } from './uploader-base';
+import { encodeOSSKey } from './oss-path';
 import type { UploadResult, ImageHostingConfig, AliyunOSSConfig, UploadContext } from '../types';
 
 export class AliyunOSSUploader extends UploaderBase {
@@ -24,8 +25,10 @@ export class AliyunOSSUploader extends UploaderBase {
         const contentType = this.guessMimeType(filename);
         const region = this.parseRegion(ossConfig.region);
         const host = `${ossConfig.bucket}.oss-${region}.aliyuncs.com`;
-        const url = `https://${host}/${targetPath}`;
+        const encodedPath = encodeOSSKey(targetPath);
+        const url = `https://${host}/${encodedPath}`;
         const date = new Date().toUTCString();
+        // OSS V1 signs the logical object key, while the request URL uses its encoded form.
         const resourcePath = `/${ossConfig.bucket}/${targetPath}`;
         const stringToSign = `PUT\n\n${contentType}\n${date}\n${resourcePath}`;
         const signature = await this.hmacSha1Base64(stringToSign, ossConfig.accessKeySecret);
@@ -48,7 +51,7 @@ export class AliyunOSSUploader extends UploaderBase {
                 return { success: false, error: `HTTP ${resp.status}: ${resp.text}`, originalPath: filename };
             }
             const publicUrl = this.config.urlPrefix
-                ? `${this.config.urlPrefix}/${targetPath}`
+                ? `${this.config.urlPrefix}/${encodedPath}`
                 : url;
             return { success: true, url: publicUrl, originalPath: filename };
         } catch (e) {

--- a/src/uploaders/oss-path.ts
+++ b/src/uploaders/oss-path.ts
@@ -1,0 +1,9 @@
+/** Encode each OSS object key segment while preserving path separators. */
+export function encodeOSSKey(key: string): string {
+    return key
+        .split('/')
+        .map((segment) => encodeURIComponent(segment).replace(/[!'()*]/g, (character) =>
+            `%${character.charCodeAt(0).toString(16).toUpperCase()}`
+        ))
+        .join('/');
+}

--- a/tests/aliyun-oss.test.ts
+++ b/tests/aliyun-oss.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AliyunOSSConfig, ImageHostingConfig } from '../src/types';
+
+const { requestUrl } = vi.hoisted(() => ({ requestUrl: vi.fn() }));
+
+vi.mock('obsidian', () => ({ requestUrl }));
+
+import { AliyunOSSUploader } from '../src/uploaders/aliyun-oss';
+import { encodeOSSKey } from '../src/uploaders/oss-path';
+
+const FIXED_DATE = new Date('2026-07-14T06:00:00.000Z');
+
+function createOSSConfig(): AliyunOSSConfig {
+    return {
+        region: 'cn-hangzhou',
+        accessKeyId: 'access-key',
+        accessKeySecret: 'secret-key',
+        bucket: 'images',
+    };
+}
+
+function createHostingConfig(urlPrefix = ''): ImageHostingConfig {
+    return {
+        id: 'aliyun-test',
+        name: 'Aliyun test',
+        type: 'aliyun-oss',
+        enabled: true,
+        config: createOSSConfig(),
+        uploadPath: 'uploads/{filename}.{ext}',
+        urlPrefix,
+    };
+}
+
+async function hmacSha1Base64(value: string, secret: string): Promise<string> {
+    const encoder = new TextEncoder();
+    const key = await crypto.subtle.importKey(
+        'raw',
+        encoder.encode(secret),
+        { name: 'HMAC', hash: 'SHA-1' },
+        false,
+        ['sign']
+    );
+    const signature = await crypto.subtle.sign('HMAC', key, encoder.encode(value));
+    return btoa(String.fromCharCode(...new Uint8Array(signature)));
+}
+
+describe('Aliyun OSS path construction', () => {
+    it('encodes object key segments and preserves path separators', () => {
+        expect(encodeOSSKey("folder/中文 图#1?!'()*.png")).toBe(
+            'folder/%E4%B8%AD%E6%96%87%20%E5%9B%BE%231%3F%21%27%28%29%2A.png'
+        );
+        expect(encodeOSSKey('folder/ascii-file.png')).toBe('folder/ascii-file.png');
+    });
+});
+
+describe('AliyunOSSUploader', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(FIXED_DATE);
+        requestUrl.mockReset();
+        requestUrl.mockResolvedValue({ status: 200, text: '' });
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('encodes request and public URLs but signs the logical object key', async () => {
+        const uploader = new AliyunOSSUploader(
+            createHostingConfig('https://cdn.example.com/root')
+        );
+        const filename = '中文 图#1?.png';
+        const targetPath = `uploads/${filename}`;
+        const encodedPath = 'uploads/%E4%B8%AD%E6%96%87%20%E5%9B%BE%231%3F.png';
+        const date = FIXED_DATE.toUTCString();
+        const stringToSign = `PUT\n\nimage/png\n${date}\n/images/${targetPath}`;
+        const expectedSignature = await hmacSha1Base64(stringToSign, 'secret-key');
+
+        const result = await uploader.upload(new ArrayBuffer(0), filename);
+        const request: unknown = requestUrl.mock.calls[0]?.[0];
+
+        expect(request).toMatchObject({
+            url: `https://images.oss-cn-hangzhou.aliyuncs.com/${encodedPath}`,
+            headers: {
+                Authorization: `OSS access-key:${expectedSignature}`,
+                Date: date,
+                'Content-Type': 'image/png',
+            },
+        });
+        expect(result).toMatchObject({
+            success: true,
+            url: `https://cdn.example.com/root/${encodedPath}`,
+        });
+    });
+});


### PR DESCRIPTION
## 概要

修复 Aliyun OSS 对象 key 包含中文、空格、`#`、`?` 等字符时的请求 URL 构造，并保持 OSS V1 签名资源与逻辑对象名一致。

Closes #10

## 根因与处理

当前上传器直接把未编码的对象 key 拼入 URL，保留字符可能被解析为查询参数或片段。

本 PR 将两个语义明确分开：

- 请求 URL 与公开 URL：按路径段进行 RFC 3986 百分号编码，保留目录分隔符 `/`
- OSS V1 `CanonicalizedResource`：继续使用原始逻辑对象 key

这与 [Aliyun OSS V1 Authorization 文档](https://www.alibabacloud.com/help/en/oss/developer-reference/include-signatures-in-the-authorization-header) 以及 [Aliyun OSS JavaScript SDK](https://github.com/ali-sdk/ali-oss/blob/master/lib/client.js) 的请求 URL / 签名资源分工一致。

## 变更

- 新增 `encodeOSSKey()` 纯函数
- Aliyun OSS PUT 请求使用编码后的 URL
- 自定义 `urlPrefix` 返回编码后的公开 URL
- V1 Authorization 测试确认签名仍基于原始对象 key
- 更新项目上传器文档

## 验证

- `npm test`：6 个测试文件、39 项测试通过
- `npm run build`：通过
- `git diff --check`：通过

## 来源与边界

感谢 @jankenliu 在 #5 的提交 [38cb1b0](https://github.com/jankenliu/obsidian-image-manager/commit/38cb1b026fa24d66459ac64bd414de1043a6bece) 提出初始方案。

本 PR 没有原样移植该提交：百分号编码路径不用于 V1 `CanonicalizedResource`，并排除了乱码注释、BOM、`package-lock.json` 删除及已由 #9 处理的 `{sourceDir}` 功能。OSS V4、STS、CNAME 和分片上传不在本 PR 范围内。
